### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "blessed-contrib": "0.0.8",
     "js-yaml": "^3.2.5",
     "moment": "~2.9.0",
-    "request": "~2.51.0",
+    "request": "~2.74.0",
     "yargs": "~1.3.3"
   },
   "preferGlobal": "true",


### PR DESCRIPTION
cli-dashboard currently has a 4 vulnerable dependency paths, introducing 3 different types of known vulnerabilities.

This PR fixes 2 vulnerable dependency paths, [ReDOS vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency and [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.

You can see [Snyk test report](https://snyk.io/test/github/Graylog2/cli-dashboard) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix all the vulnerabilities listed above.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade others dependencies as well.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)
